### PR TITLE
Add prototype health features

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # tstj_app
 
-A new Flutter project.
+Prototype health tracking Flutter application with mock data.
 
 ## Getting Started
 
@@ -14,3 +14,10 @@ A few resources to get you started if this is your first Flutter project:
 For help getting started with Flutter development, view the
 [online documentation](https://docs.flutter.dev/), which offers tutorials,
 samples, guidance on mobile development, and a full API reference.
+
+## Features
+
+- Log basic health data such as blood pressure, blood sugar and weight.
+- Manage medication reminders (mock only).
+- Watch health related videos embedded from YouTube.
+- View a simple chart of logged data and export the list to PDF.

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,5 +1,12 @@
 import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
 import 'pages/home_page.dart';
+import 'providers/health_data_provider.dart';
+import 'providers/medication_provider.dart';
+import 'pages/health_log_page.dart';
+import 'pages/medication_page.dart';
+import 'pages/video_library_page.dart';
+import 'pages/report_page.dart';
 
 void main() {
   runApp(const InitialApp());
@@ -12,13 +19,25 @@ class InitialApp extends StatelessWidget {
   // This widget is the root of your application.
   @override
   Widget build(BuildContext context) {
-    return MaterialApp(
-      title: 'เติมใจเติมสุข',
-      theme: ThemeData(
-        fontFamily: 'Sarabun',
-        colorScheme: ColorScheme.fromSwatch().copyWith(primary: primaryColor),
+    return MultiProvider(
+      providers: [
+        ChangeNotifierProvider(create: (_) => HealthDataProvider()),
+        ChangeNotifierProvider(create: (_) => MedicationProvider()),
+      ],
+      child: MaterialApp(
+        title: 'เติมใจเติมสุข',
+        theme: ThemeData(
+          fontFamily: 'Sarabun',
+          colorScheme: ColorScheme.fromSwatch().copyWith(primary: primaryColor),
+        ),
+        routes: {
+          '/': (context) => const HomePage(),
+          '/health-log': (context) => const HealthLogPage(),
+          '/medication': (context) => const MedicationPage(),
+          '/videos': (context) => VideoLibraryPage(),
+          '/report': (context) => const ReportPage(),
+        },
       ),
-      home: HomePage(),
     );
   }
 }

--- a/lib/models/health_entry.dart
+++ b/lib/models/health_entry.dart
@@ -1,0 +1,18 @@
+import 'package:flutter/material.dart';
+
+/// Represents a single log of health data.
+class HealthEntry {
+  HealthEntry({
+    required this.date,
+    required this.systolic,
+    required this.diastolic,
+    required this.bloodSugar,
+    required this.weight,
+  });
+
+  final DateTime date;
+  final int systolic;
+  final int diastolic;
+  final int bloodSugar;
+  final double weight;
+}

--- a/lib/models/medication_reminder.dart
+++ b/lib/models/medication_reminder.dart
@@ -1,0 +1,7 @@
+/// Represents a reminder to take medication.
+class MedicationReminder {
+  MedicationReminder({required this.time, required this.name});
+
+  final String name; // Name of the medication
+  final DateTime time; // Time to take it
+}

--- a/lib/models/video_item.dart
+++ b/lib/models/video_item.dart
@@ -1,0 +1,7 @@
+/// Simple model for a video in the library.
+class VideoItem {
+  const VideoItem({required this.title, required this.url});
+
+  final String title;
+  final String url; // YouTube video url
+}

--- a/lib/pages/health_log_page.dart
+++ b/lib/pages/health_log_page.dart
@@ -1,0 +1,89 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import '../models/health_entry.dart';
+import '../providers/health_data_provider.dart';
+
+/// Screen that allows users to log health data.
+class HealthLogPage extends StatefulWidget {
+  const HealthLogPage({super.key});
+
+  @override
+  State<HealthLogPage> createState() => _HealthLogPageState();
+}
+
+class _HealthLogPageState extends State<HealthLogPage> {
+  final _formKey = GlobalKey<FormState>();
+  final _systolicController = TextEditingController();
+  final _diastolicController = TextEditingController();
+  final _sugarController = TextEditingController();
+  final _weightController = TextEditingController();
+
+  @override
+  void dispose() {
+    _systolicController.dispose();
+    _diastolicController.dispose();
+    _sugarController.dispose();
+    _weightController.dispose();
+    super.dispose();
+  }
+
+  void _saveEntry() {
+    if (_formKey.currentState!.validate()) {
+      final entry = HealthEntry(
+        date: DateTime.now(),
+        systolic: int.parse(_systolicController.text),
+        diastolic: int.parse(_diastolicController.text),
+        bloodSugar: int.parse(_sugarController.text),
+        weight: double.parse(_weightController.text),
+      );
+      Provider.of<HealthDataProvider>(context, listen: false).addEntry(entry);
+      Navigator.pop(context);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('บันทึกสุขภาพ')),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Form(
+          key: _formKey,
+          child: ListView(
+            children: [
+              TextFormField(
+                controller: _systolicController,
+                decoration: const InputDecoration(labelText: 'ความดันบน (mmHg)'),
+                keyboardType: TextInputType.number,
+                validator: (v) => v!.isEmpty ? 'กรุณาใส่ค่า' : null,
+              ),
+              TextFormField(
+                controller: _diastolicController,
+                decoration: const InputDecoration(labelText: 'ความดันล่าง (mmHg)'),
+                keyboardType: TextInputType.number,
+                validator: (v) => v!.isEmpty ? 'กรุณาใส่ค่า' : null,
+              ),
+              TextFormField(
+                controller: _sugarController,
+                decoration: const InputDecoration(labelText: 'น้ำตาลในเลือด (mg/dL)'),
+                keyboardType: TextInputType.number,
+                validator: (v) => v!.isEmpty ? 'กรุณาใส่ค่า' : null,
+              ),
+              TextFormField(
+                controller: _weightController,
+                decoration: const InputDecoration(labelText: 'น้ำหนัก (kg)'),
+                keyboardType: TextInputType.number,
+                validator: (v) => v!.isEmpty ? 'กรุณาใส่ค่า' : null,
+              ),
+              const SizedBox(height: 24),
+              ElevatedButton(
+                onPressed: _saveEntry,
+                child: const Text('บันทึก'),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/pages/home_page.dart
+++ b/lib/pages/home_page.dart
@@ -35,11 +35,9 @@ class _HomePageState extends State<HomePage> {
                   mainAxisAlignment: MainAxisAlignment.spaceAround,
                   children: [
                     _buildCircleButton(
-                      0,
-                      Icons.play_circle_fill,
-                      'ดูคลิปสุขภาพ',
-                    ),
-                    _buildCircleButton(1, Icons.edit_note, 'บันทึกสุขภาพ'),
+                        0, Icons.play_circle_fill, 'ดูคลิปสุขภาพ', '/videos'),
+                    _buildCircleButton(
+                        1, Icons.edit_note, 'บันทึกสุขภาพ', '/health-log'),
                     _buildCircleButton(
                       2,
                       Icons.medical_services,
@@ -114,7 +112,9 @@ class _HomePageState extends State<HomePage> {
                 ),
                 const SizedBox(height: 12),
                 ElevatedButton.icon(
-                  onPressed: () {},
+                  onPressed: () {
+                    Navigator.pushNamed(context, '/health-log');
+                  },
                   icon: const Icon(Icons.add),
                   label: const Text(
                     'เพิ่มข้อมูลสุขภาพ',
@@ -156,13 +156,14 @@ class _HomePageState extends State<HomePage> {
                 ],
               ),
             ),
-            _buildDrawerItem(Icons.home, 'หน้าแรก'),
-            _buildDrawerItem(Icons.edit_note, 'บันทึกสุขภาพ'),
-            _buildDrawerItem(Icons.notifications_active, 'แจ้งเตือนยา'),
-            _buildDrawerItem(Icons.play_circle_fill, 'ดูคลิปสุขภาพ'),
+            _buildDrawerItem(Icons.home, 'หน้าแรก', '/'),
+            _buildDrawerItem(Icons.edit_note, 'บันทึกสุขภาพ', '/health-log'),
+            _buildDrawerItem(
+                Icons.notifications_active, 'แจ้งเตือนยา', '/medication'),
+            _buildDrawerItem(Icons.play_circle_fill, 'ดูคลิปสุขภาพ', '/videos'),
             _buildDrawerItem(Icons.medical_services, 'ปรึกษาแพทย์'),
-            _buildDrawerItem(Icons.bar_chart, 'รายงานย้อนหลัง'),
-            _buildDrawerItem(Icons.picture_as_pdf, 'ดาวน์โหลด PDF'),
+            _buildDrawerItem(Icons.bar_chart, 'รายงานย้อนหลัง', '/report'),
+            _buildDrawerItem(Icons.picture_as_pdf, 'ดาวน์โหลด PDF', '/report'),
             _buildDrawerItem(Icons.settings, 'ตั้งค่าผู้ใช้งาน'),
           ],
         ),
@@ -170,7 +171,8 @@ class _HomePageState extends State<HomePage> {
     );
   }
 
-  Widget _buildCircleButton(int index, IconData icon, String label) {
+  Widget _buildCircleButton(int index, IconData icon, String label,
+      [String? route]) {
     return Column(
       children: [
         GestureDetector(
@@ -191,7 +193,9 @@ class _HomePageState extends State<HomePage> {
                 customBorder: const CircleBorder(),
                 splashColor: Colors.orangeAccent.withOpacity(0.3),
                 onTap: () {
-                  // เพิ่ม logic เมื่อคลิกจริง
+                  if (route != null) {
+                    Navigator.pushNamed(context, route);
+                  }
                 },
                 child: Padding(
                   padding: const EdgeInsets.all(16.0),
@@ -223,13 +227,15 @@ class _HomePageState extends State<HomePage> {
     );
   }
 
-  Widget _buildDrawerItem(IconData icon, String title) {
+  Widget _buildDrawerItem(IconData icon, String title, [String? route]) {
     return ListTile(
       leading: Icon(icon, color: primaryColor),
       title: Text(title, style: const TextStyle(fontSize: 18)),
       onTap: () {
         Navigator.pop(context);
-        // TODO: เพิ่ม Navigator.push ไปยังหน้าที่ต้องการ
+        if (route != null) {
+          Navigator.pushNamed(context, route);
+        }
       },
     );
   }

--- a/lib/pages/medication_page.dart
+++ b/lib/pages/medication_page.dart
@@ -1,0 +1,92 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import '../models/medication_reminder.dart';
+import '../providers/medication_provider.dart';
+
+/// Page listing medication reminders.
+class MedicationPage extends StatelessWidget {
+  const MedicationPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('แจ้งเตือนยา')),
+      body: Consumer<MedicationProvider>(
+        builder: (context, provider, _) {
+          return ListView.builder(
+            itemCount: provider.reminders.length,
+            itemBuilder: (context, index) {
+              final reminder = provider.reminders[index];
+              return ListTile(
+                title: Text(reminder.name),
+                subtitle: Text('เวลา ${reminder.time.hour}:${reminder.time.minute.toString().padLeft(2, '0')}'),
+              );
+            },
+          );
+        },
+      ),
+      floatingActionButton: FloatingActionButton(
+        onPressed: () => _addReminder(context),
+        child: const Icon(Icons.add),
+      ),
+    );
+  }
+
+  Future<void> _addReminder(BuildContext context) async {
+    final nameController = TextEditingController();
+    TimeOfDay? selectedTime;
+    await showDialog(
+      context: context,
+      builder: (context) {
+        return AlertDialog(
+          title: const Text('เพิ่มการเตือนยา'),
+          content: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              TextField(
+                controller: nameController,
+                decoration: const InputDecoration(labelText: 'ชื่อยา'),
+              ),
+              const SizedBox(height: 8),
+              ElevatedButton(
+                onPressed: () async {
+                  final time = await showTimePicker(
+                    context: context,
+                    initialTime: TimeOfDay.now(),
+                  );
+                  if (time != null) {
+                    selectedTime = time;
+                  }
+                },
+                child: const Text('เลือกเวลา'),
+              ),
+            ],
+          ),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.pop(context),
+              child: const Text('ยกเลิก'),
+            ),
+            TextButton(
+              onPressed: () {
+                if (selectedTime != null && nameController.text.isNotEmpty) {
+                  final now = DateTime.now();
+                  final dt = DateTime(now.year, now.month, now.day,
+                      selectedTime!.hour, selectedTime!.minute);
+                  final reminder = MedicationReminder(
+                    name: nameController.text,
+                    time: dt,
+                  );
+                  Provider.of<MedicationProvider>(context, listen: false)
+                      .addReminder(reminder);
+                  Navigator.pop(context);
+                }
+              },
+              child: const Text('บันทึก'),
+            ),
+          ],
+        );
+      },
+    );
+  }
+}

--- a/lib/pages/report_page.dart
+++ b/lib/pages/report_page.dart
@@ -1,0 +1,65 @@
+import 'package:flutter/material.dart';
+import 'package:fl_chart/fl_chart.dart';
+import 'package:provider/provider.dart';
+import 'package:pdf/widgets.dart' as pw;
+import 'package:printing/printing.dart';
+import '../providers/health_data_provider.dart';
+
+/// Page displaying simple charts of health data and allowing export to PDF.
+class ReportPage extends StatelessWidget {
+  const ReportPage({super.key});
+
+  Future<void> _exportPDF(BuildContext context) async {
+    final entries =
+        Provider.of<HealthDataProvider>(context, listen: false).entries;
+    final pdf = pw.Document();
+    pdf.addPage(
+      pw.Page(
+        build: (context) => pw.Column(
+          children: entries
+              .map((e) => pw.Text(
+                  '${e.date}: BP ${e.systolic}/${e.diastolic} mmHg, Sugar ${e.bloodSugar}, Weight ${e.weight}'))
+              .toList(),
+        ),
+      ),
+    );
+    await Printing.layoutPdf(onLayout: (format) => pdf.save());
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('รายงานย้อนหลัง'),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.picture_as_pdf),
+            onPressed: () => _exportPDF(context),
+          )
+        ],
+      ),
+      body: Consumer<HealthDataProvider>(
+        builder: (context, provider, _) {
+          final spots = provider.entries
+              .asMap()
+              .entries
+              .map((e) => FlSpot(
+                    e.key.toDouble(),
+                    e.value.systolic.toDouble(),
+                  ))
+              .toList();
+          return Padding(
+            padding: const EdgeInsets.all(16),
+            child: LineChart(
+              LineChartData(
+                lineBarsData: [
+                  LineChartBarData(spots: spots, isCurved: true),
+                ],
+              ),
+            ),
+          );
+        },
+      ),
+    );
+  }
+}

--- a/lib/pages/video_library_page.dart
+++ b/lib/pages/video_library_page.dart
@@ -1,0 +1,45 @@
+import 'package:flutter/material.dart';
+import 'package:youtube_player_flutter/youtube_player_flutter.dart';
+import '../models/video_item.dart';
+
+/// Simple page displaying health videos using YouTubePlayer.
+class VideoLibraryPage extends StatelessWidget {
+  VideoLibraryPage({super.key});
+
+  final List<VideoItem> _videos = const [
+    VideoItem(title: 'วิธีดูแลสุขภาพ', url: 'https://www.youtube.com/watch?v=K18cpp_-gP8'),
+    VideoItem(title: 'การออกกำลังกายง่ายๆ', url: 'https://www.youtube.com/watch?v=5qap5aO4i9A'),
+  ];
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('คลิปสุขภาพ')),
+      body: ListView.builder(
+        itemCount: _videos.length,
+        itemBuilder: (context, index) {
+          final video = _videos[index];
+          final controller = YoutubePlayerController(
+            initialVideoId: YoutubePlayer.convertUrlToId(video.url) ?? '',
+            flags: const YoutubePlayerFlags(autoPlay: false),
+          );
+          return Padding(
+            padding: const EdgeInsets.all(8.0),
+            child: Card(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  YoutubePlayer(controller: controller, showVideoProgressIndicator: true),
+                  Padding(
+                    padding: const EdgeInsets.all(8.0),
+                    child: Text(video.title, style: const TextStyle(fontSize: 16)),
+                  ),
+                ],
+              ),
+            ),
+          );
+        },
+      ),
+    );
+  }
+}

--- a/lib/providers/health_data_provider.dart
+++ b/lib/providers/health_data_provider.dart
@@ -1,0 +1,15 @@
+import 'package:flutter/material.dart';
+import '../models/health_entry.dart';
+
+/// Holds the logged health data in memory. This can later be replaced with real
+/// persistence.
+class HealthDataProvider extends ChangeNotifier {
+  final List<HealthEntry> _entries = [];
+
+  List<HealthEntry> get entries => List.unmodifiable(_entries);
+
+  void addEntry(HealthEntry entry) {
+    _entries.add(entry);
+    notifyListeners();
+  }
+}

--- a/lib/providers/medication_provider.dart
+++ b/lib/providers/medication_provider.dart
@@ -1,0 +1,15 @@
+import 'package:flutter/material.dart';
+import '../models/medication_reminder.dart';
+
+/// Stores medication reminders. Replace with local notification integration
+/// when implementing real reminders.
+class MedicationProvider extends ChangeNotifier {
+  final List<MedicationReminder> _reminders = [];
+
+  List<MedicationReminder> get reminders => List.unmodifiable(_reminders);
+
+  void addReminder(MedicationReminder reminder) {
+    _reminders.add(reminder);
+    notifyListeners();
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -34,6 +34,11 @@ dependencies:
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.8
+  provider: ^6.1.2
+  fl_chart: ^0.66.2
+  pdf: ^3.10.7
+  printing: ^5.12.0
+  youtube_player_flutter: ^8.1.2
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- prototype health tracking app
- add provider, chart, pdf, youtube dependencies
- implement data models and providers
- add health log, medication, video library, report pages
- wire up navigation and drawer

## Testing
- `dart format -o none --set-exit-if-changed lib README.md pubspec.yaml`
- `flutter analyze`
- `flutter test`

------
https://chatgpt.com/codex/tasks/task_e_685916ed679883299f27021178c87875