### PR TITLE
Add wellness app prototype

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# tstj_app
+# Wellness App
 
-Prototype health tracking Flutter application with mock data.
+Prototype Flutter application providing a foundation for future health tracking features.
 
 ## Getting Started
 
@@ -17,7 +17,8 @@ samples, guidance on mobile development, and a full API reference.
 
 ## Features
 
-- Log basic health data such as blood pressure, blood sugar and weight.
-- Manage medication reminders (mock only).
-- Watch health related videos embedded from YouTube.
-- View a simple chart of logged data and export the list to PDF.
+- Welcome flow with login and registration screens (mock logic).
+- Dashboard with bottom navigation for health summary, history, reminders and settings.
+- Form to log blood pressure, blood sugar and weight.
+- Local storage using `SharedPreferences` for logged data and reminders.
+- Example API call fetching sample JSON data.

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,42 +1,47 @@
 import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
 import 'package:provider/provider.dart';
-import 'pages/home_page.dart';
+
 import 'providers/health_data_provider.dart';
 import 'providers/medication_provider.dart';
-import 'pages/health_log_page.dart';
-import 'pages/medication_page.dart';
-import 'pages/video_library_page.dart';
-import 'pages/report_page.dart';
+import 'screens/dashboard_screen.dart';
+import 'screens/health_form_screen.dart';
+import 'screens/login_screen.dart';
+import 'screens/register_screen.dart';
+import 'screens/welcome_screen.dart';
+import 'utils/app_theme.dart';
 
 void main() {
-  runApp(const InitialApp());
+  runApp(const WellnessApp());
 }
 
-class InitialApp extends StatelessWidget {
-  const InitialApp({super.key});
-  static const Color primaryColor = Color(0xFFF7931E);
+/// Root widget with providers and router.
+class WellnessApp extends StatelessWidget {
+  const WellnessApp({super.key});
 
-  // This widget is the root of your application.
   @override
   Widget build(BuildContext context) {
+    final router = GoRouter(
+      routes: [
+        GoRoute(path: '/', builder: (c, s) => const DashboardScreen()),
+        GoRoute(path: '/add', builder: (c, s) => const HealthFormScreen()),
+        GoRoute(path: '/login', builder: (c, s) => const LoginScreen()),
+        GoRoute(path: '/register', builder: (c, s) => const RegisterScreen()),
+        GoRoute(path: '/welcome', builder: (c, s) => const WelcomeScreen()),
+      ],
+      initialLocation: '/welcome',
+    );
+
     return MultiProvider(
       providers: [
         ChangeNotifierProvider(create: (_) => HealthDataProvider()),
         ChangeNotifierProvider(create: (_) => MedicationProvider()),
       ],
-      child: MaterialApp(
-        title: 'เติมใจเติมสุข',
-        theme: ThemeData(
-          fontFamily: 'Sarabun',
-          colorScheme: ColorScheme.fromSwatch().copyWith(primary: primaryColor),
-        ),
-        routes: {
-          '/': (context) => const HomePage(),
-          '/health-log': (context) => const HealthLogPage(),
-          '/medication': (context) => const MedicationPage(),
-          '/videos': (context) => VideoLibraryPage(),
-          '/report': (context) => const ReportPage(),
-        },
+      child: MaterialApp.router(
+        title: 'Wellness App',
+        theme: AppTheme.light(),
+        darkTheme: AppTheme.dark(),
+        routerConfig: router,
       ),
     );
   }

--- a/lib/models/health_entry.dart
+++ b/lib/models/health_entry.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 
 /// Represents a single log of health data.
+/// Represents a single log of health data.
 class HealthEntry {
   HealthEntry({
     required this.date,
@@ -15,4 +16,22 @@ class HealthEntry {
   final int diastolic;
   final int bloodSugar;
   final double weight;
+
+  /// Converts this entry to a JSON encodable map.
+  Map<String, dynamic> toMap() => {
+        'date': date.toIso8601String(),
+        'systolic': systolic,
+        'diastolic': diastolic,
+        'bloodSugar': bloodSugar,
+        'weight': weight,
+      };
+
+  /// Creates an entry from a previously encoded map.
+  factory HealthEntry.fromMap(Map<String, dynamic> map) => HealthEntry(
+        date: DateTime.parse(map['date'] as String),
+        systolic: map['systolic'] as int,
+        diastolic: map['diastolic'] as int,
+        bloodSugar: map['bloodSugar'] as int,
+        weight: (map['weight'] as num).toDouble(),
+      );
 }

--- a/lib/models/medication_reminder.dart
+++ b/lib/models/medication_reminder.dart
@@ -1,7 +1,21 @@
 /// Represents a reminder to take medication.
+/// Represents a reminder to take medication.
 class MedicationReminder {
   MedicationReminder({required this.time, required this.name});
 
   final String name; // Name of the medication
   final DateTime time; // Time to take it
+
+  /// Converts the reminder to a JSON encodable map.
+  Map<String, dynamic> toMap() => {
+        'name': name,
+        'time': time.toIso8601String(),
+      };
+
+  /// Creates a reminder from stored data.
+  factory MedicationReminder.fromMap(Map<String, dynamic> map) =>
+      MedicationReminder(
+        name: map['name'] as String,
+        time: DateTime.parse(map['time'] as String),
+      );
 }

--- a/lib/providers/health_data_provider.dart
+++ b/lib/providers/health_data_provider.dart
@@ -1,15 +1,34 @@
 import 'package:flutter/material.dart';
 import '../models/health_entry.dart';
+import '../services/local_storage_service.dart';
 
 /// Holds the logged health data in memory. This can later be replaced with real
 /// persistence.
 class HealthDataProvider extends ChangeNotifier {
   final List<HealthEntry> _entries = [];
 
+  HealthDataProvider() {
+    _load();
+  }
+
   List<HealthEntry> get entries => List.unmodifiable(_entries);
 
   void addEntry(HealthEntry entry) {
     _entries.add(entry);
+    _save();
     notifyListeners();
+  }
+
+  Future<void> _load() async {
+    final data = await LocalStorageService.instance.loadHealthEntries();
+    _entries
+      ..clear()
+      ..addAll(data.map((e) => HealthEntry.fromMap(e as Map<String, dynamic>)));
+    notifyListeners();
+  }
+
+  Future<void> _save() async {
+    final list = _entries.map((e) => e.toMap()).toList();
+    await LocalStorageService.instance.saveHealthEntries(list);
   }
 }

--- a/lib/providers/medication_provider.dart
+++ b/lib/providers/medication_provider.dart
@@ -1,15 +1,36 @@
 import 'package:flutter/material.dart';
 import '../models/medication_reminder.dart';
+import '../services/local_storage_service.dart';
 
 /// Stores medication reminders. Replace with local notification integration
 /// when implementing real reminders.
 class MedicationProvider extends ChangeNotifier {
   final List<MedicationReminder> _reminders = [];
 
+  MedicationProvider() {
+    _load();
+  }
+
   List<MedicationReminder> get reminders => List.unmodifiable(_reminders);
 
   void addReminder(MedicationReminder reminder) {
     _reminders.add(reminder);
+    _save();
     notifyListeners();
+  }
+
+  Future<void> _load() async {
+    final data = await LocalStorageService.instance.loadReminders();
+    _reminders
+      ..clear()
+      ..addAll(
+        data.map((e) => MedicationReminder.fromMap(e as Map<String, dynamic>)),
+      );
+    notifyListeners();
+  }
+
+  Future<void> _save() async {
+    final list = _reminders.map((e) => e.toMap()).toList();
+    await LocalStorageService.instance.saveReminders(list);
   }
 }

--- a/lib/screens/dashboard_screen.dart
+++ b/lib/screens/dashboard_screen.dart
@@ -1,0 +1,67 @@
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+import 'package:provider/provider.dart';
+
+import '../services/api_service.dart';
+import '../providers/health_data_provider.dart';
+import 'data_history_screen.dart';
+import 'health_form_screen.dart';
+import 'health_summary_screen.dart';
+import 'reminders_screen.dart';
+import 'settings_screen.dart';
+
+/// Main dashboard with bottom navigation.
+class DashboardScreen extends StatefulWidget {
+  const DashboardScreen({super.key});
+
+  @override
+  State<DashboardScreen> createState() => _DashboardScreenState();
+}
+
+class _DashboardScreenState extends State<DashboardScreen> {
+  int _index = 0;
+  Map<String, dynamic>? _apiData;
+
+  @override
+  void initState() {
+    super.initState();
+    _fetchData();
+  }
+
+  Future<void> _fetchData() async {
+    final data = await const ApiService().fetchExamplePost();
+    setState(() => _apiData = data);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final pages = [
+      const HealthSummaryScreen(),
+      const DataHistoryScreen(),
+      const RemindersScreen(),
+      const SettingsScreen(),
+    ];
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(_apiData != null ? _apiData!['title'] as String : 'Dashboard'),
+      ),
+      body: IndexedStack(index: _index, children: pages),
+      bottomNavigationBar: BottomNavigationBar(
+        currentIndex: _index,
+        onTap: (i) => setState(() => _index = i),
+        items: const [
+          BottomNavigationBarItem(icon: Icon(Icons.home), label: 'Home'),
+          BottomNavigationBarItem(icon: Icon(Icons.history), label: 'History'),
+          BottomNavigationBarItem(icon: Icon(Icons.alarm), label: 'Reminders'),
+          BottomNavigationBarItem(icon: Icon(Icons.settings), label: 'Settings'),
+        ],
+      ),
+      floatingActionButton: _index == 1
+          ? FloatingActionButton(
+              onPressed: () => context.push('/add'),
+              child: const Icon(Icons.add),
+            )
+          : null,
+    );
+  }
+}

--- a/lib/screens/data_history_screen.dart
+++ b/lib/screens/data_history_screen.dart
@@ -1,0 +1,25 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import '../providers/health_data_provider.dart';
+
+/// Displays logged health entries in a list.
+class DataHistoryScreen extends StatelessWidget {
+  const DataHistoryScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final entries = context.watch<HealthDataProvider>().entries;
+    return ListView.builder(
+      itemCount: entries.length,
+      itemBuilder: (context, index) {
+        final e = entries[index];
+        return ListTile(
+          title: Text('${e.systolic}/${e.diastolic} mmHg'),
+          subtitle: Text(
+              'Sugar: ${e.bloodSugar} mg/dL  Weight: ${e.weight} kg'),
+          trailing: Text('${e.date.month}/${e.date.day}'),
+        );
+      },
+    );
+  }
+}

--- a/lib/screens/health_form_screen.dart
+++ b/lib/screens/health_form_screen.dart
@@ -1,0 +1,86 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import '../models/health_entry.dart';
+import '../providers/health_data_provider.dart';
+
+/// Form screen for entering health data.
+class HealthFormScreen extends StatefulWidget {
+  const HealthFormScreen({super.key});
+
+  @override
+  State<HealthFormScreen> createState() => _HealthFormScreenState();
+}
+
+class _HealthFormScreenState extends State<HealthFormScreen> {
+  final _formKey = GlobalKey<FormState>();
+  final _systolicController = TextEditingController();
+  final _diastolicController = TextEditingController();
+  final _sugarController = TextEditingController();
+  final _weightController = TextEditingController();
+
+  @override
+  void dispose() {
+    _systolicController.dispose();
+    _diastolicController.dispose();
+    _sugarController.dispose();
+    _weightController.dispose();
+    super.dispose();
+  }
+
+  void _saveEntry() {
+    if (_formKey.currentState!.validate()) {
+      final entry = HealthEntry(
+        date: DateTime.now(),
+        systolic: int.parse(_systolicController.text),
+        diastolic: int.parse(_diastolicController.text),
+        bloodSugar: int.parse(_sugarController.text),
+        weight: double.parse(_weightController.text),
+      );
+      context.read<HealthDataProvider>().addEntry(entry);
+      Navigator.pop(context);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Log Health Data')),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Form(
+          key: _formKey,
+          child: ListView(
+            children: [
+              TextFormField(
+                controller: _systolicController,
+                decoration: const InputDecoration(labelText: 'Systolic (mmHg)'),
+                keyboardType: TextInputType.number,
+                validator: (v) => v!.isEmpty ? 'Required' : null,
+              ),
+              TextFormField(
+                controller: _diastolicController,
+                decoration: const InputDecoration(labelText: 'Diastolic (mmHg)'),
+                keyboardType: TextInputType.number,
+                validator: (v) => v!.isEmpty ? 'Required' : null,
+              ),
+              TextFormField(
+                controller: _sugarController,
+                decoration: const InputDecoration(labelText: 'Blood Sugar (mg/dL)'),
+                keyboardType: TextInputType.number,
+                validator: (v) => v!.isEmpty ? 'Required' : null,
+              ),
+              TextFormField(
+                controller: _weightController,
+                decoration: const InputDecoration(labelText: 'Weight (kg)'),
+                keyboardType: TextInputType.number,
+                validator: (v) => v!.isEmpty ? 'Required' : null,
+              ),
+              const SizedBox(height: 24),
+              ElevatedButton(onPressed: _saveEntry, child: const Text('Save')),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/health_summary_screen.dart
+++ b/lib/screens/health_summary_screen.dart
@@ -1,0 +1,29 @@
+import 'package:flutter/material.dart';
+import 'package:fl_chart/fl_chart.dart';
+import 'package:provider/provider.dart';
+import '../providers/health_data_provider.dart';
+
+/// Shows a simple line chart of health data.
+class HealthSummaryScreen extends StatelessWidget {
+  const HealthSummaryScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final entries = context.watch<HealthDataProvider>().entries;
+    final spots = entries.asMap().entries.map((e) {
+      return FlSpot(e.key.toDouble(), e.value.systolic.toDouble());
+    }).toList();
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: LineChart(
+          LineChartData(
+            lineBarsData: [
+              LineChartBarData(spots: spots),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/login_screen.dart
+++ b/lib/screens/login_screen.dart
@@ -1,0 +1,64 @@
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+
+/// Simple email/password login screen using mock logic.
+class LoginScreen extends StatefulWidget {
+  const LoginScreen({super.key});
+
+  @override
+  State<LoginScreen> createState() => _LoginScreenState();
+}
+
+class _LoginScreenState extends State<LoginScreen> {
+  final _formKey = GlobalKey<FormState>();
+  final _emailCtrl = TextEditingController();
+  final _pwdCtrl = TextEditingController();
+
+  @override
+  void dispose() {
+    _emailCtrl.dispose();
+    _pwdCtrl.dispose();
+    super.dispose();
+  }
+
+  void _login() {
+    if (_formKey.currentState!.validate()) {
+      // Mock login success
+      context.go('/');
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Login')),
+      body: Padding(
+        padding: const EdgeInsets.all(24),
+        child: Form(
+          key: _formKey,
+          child: Column(
+            children: [
+              TextFormField(
+                controller: _emailCtrl,
+                decoration: const InputDecoration(labelText: 'Email'),
+                validator: (v) => v!.isEmpty ? 'Required' : null,
+              ),
+              TextFormField(
+                controller: _pwdCtrl,
+                obscureText: true,
+                decoration: const InputDecoration(labelText: 'Password'),
+                validator: (v) => v!.isEmpty ? 'Required' : null,
+              ),
+              const SizedBox(height: 24),
+              ElevatedButton(onPressed: _login, child: const Text('Login')),
+              TextButton(
+                onPressed: () => context.go('/register'),
+                child: const Text('Create account'),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/register_screen.dart
+++ b/lib/screens/register_screen.dart
@@ -1,0 +1,60 @@
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+
+/// Mock registration screen.
+class RegisterScreen extends StatefulWidget {
+  const RegisterScreen({super.key});
+
+  @override
+  State<RegisterScreen> createState() => _RegisterScreenState();
+}
+
+class _RegisterScreenState extends State<RegisterScreen> {
+  final _formKey = GlobalKey<FormState>();
+  final _emailCtrl = TextEditingController();
+  final _pwdCtrl = TextEditingController();
+
+  @override
+  void dispose() {
+    _emailCtrl.dispose();
+    _pwdCtrl.dispose();
+    super.dispose();
+  }
+
+  void _register() {
+    if (_formKey.currentState!.validate()) {
+      // Pretend to register
+      context.go('/');
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Register')),
+      body: Padding(
+        padding: const EdgeInsets.all(24),
+        child: Form(
+          key: _formKey,
+          child: Column(
+            children: [
+              TextFormField(
+                controller: _emailCtrl,
+                decoration: const InputDecoration(labelText: 'Email'),
+                validator: (v) => v!.isEmpty ? 'Required' : null,
+              ),
+              TextFormField(
+                controller: _pwdCtrl,
+                obscureText: true,
+                decoration: const InputDecoration(labelText: 'Password'),
+                validator: (v) => v!.isEmpty ? 'Required' : null,
+              ),
+              const SizedBox(height: 24),
+              ElevatedButton(onPressed: _register, child: const Text('Register')),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/reminders_screen.dart
+++ b/lib/screens/reminders_screen.dart
@@ -1,0 +1,86 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import '../providers/medication_provider.dart';
+import '../models/medication_reminder.dart';
+
+/// Shows medication reminders and allows adding new ones.
+class RemindersScreen extends StatelessWidget {
+  const RemindersScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: Consumer<MedicationProvider>(
+        builder: (context, provider, _) {
+          return ListView.builder(
+            itemCount: provider.reminders.length,
+            itemBuilder: (context, index) {
+              final r = provider.reminders[index];
+              return ListTile(
+                title: Text(r.name),
+                subtitle: Text('${r.time.hour}:${r.time.minute.toString().padLeft(2, '0')}'),
+              );
+            },
+          );
+        },
+      ),
+      floatingActionButton: FloatingActionButton(
+        onPressed: () => _addReminder(context),
+        child: const Icon(Icons.add),
+      ),
+    );
+  }
+
+  Future<void> _addReminder(BuildContext context) async {
+    final nameController = TextEditingController();
+    TimeOfDay? selectedTime;
+    await showDialog(
+      context: context,
+      builder: (context) {
+        return AlertDialog(
+          title: const Text('Add reminder'),
+          content: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              TextField(
+                controller: nameController,
+                decoration: const InputDecoration(labelText: 'Name'),
+              ),
+              const SizedBox(height: 8),
+              ElevatedButton(
+                onPressed: () async {
+                  final time = await showTimePicker(
+                    context: context,
+                    initialTime: TimeOfDay.now(),
+                  );
+                  if (time != null) {
+                    selectedTime = time;
+                  }
+                },
+                child: const Text('Select time'),
+              ),
+            ],
+          ),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.pop(context),
+              child: const Text('Cancel'),
+            ),
+            TextButton(
+              onPressed: () {
+                if (selectedTime != null && nameController.text.isNotEmpty) {
+                  final now = DateTime.now();
+                  final dt = DateTime(now.year, now.month, now.day, selectedTime!.hour, selectedTime!.minute);
+                  final reminder = MedicationReminder(name: nameController.text, time: dt);
+                  context.read<MedicationProvider>().addReminder(reminder);
+                  Navigator.pop(context);
+                }
+              },
+              child: const Text('Save'),
+            ),
+          ],
+        );
+      },
+    );
+  }
+}

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -1,0 +1,38 @@
+import 'package:flutter/material.dart';
+
+/// Settings screen with placeholders for language and font size.
+class SettingsScreen extends StatelessWidget {
+  const SettingsScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return ListView(
+      padding: const EdgeInsets.all(16),
+      children: [
+        ListTile(
+          title: const Text('Language'),
+          trailing: DropdownButton<String>(
+            value: 'en',
+            items: const [
+              DropdownMenuItem(value: 'en', child: Text('English')),
+              DropdownMenuItem(value: 'th', child: Text('ไทย')),
+            ],
+            onChanged: (_) {},
+          ),
+        ),
+        ListTile(
+          title: const Text('Font size'),
+          trailing: DropdownButton<double>(
+            value: 16,
+            items: const [
+              DropdownMenuItem(value: 14, child: Text('Small')),
+              DropdownMenuItem(value: 16, child: Text('Normal')),
+              DropdownMenuItem(value: 20, child: Text('Large')),
+            ],
+            onChanged: (_) {},
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/screens/welcome_screen.dart
+++ b/lib/screens/welcome_screen.dart
@@ -1,0 +1,36 @@
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+
+/// Simple onboarding page with a welcome message.
+class WelcomeScreen extends StatelessWidget {
+  const WelcomeScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: Container(
+        width: double.infinity,
+        padding: const EdgeInsets.all(24),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            const Text(
+              'Wellness App',
+              style: TextStyle(fontSize: 32, fontWeight: FontWeight.bold),
+            ),
+            const SizedBox(height: 16),
+            const Text(
+              'A simple prototype to track your health and reminders.',
+              textAlign: TextAlign.center,
+            ),
+            const SizedBox(height: 32),
+            ElevatedButton(
+              onPressed: () => context.go('/login'),
+              child: const Text('Get Started'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/services/api_service.dart
+++ b/lib/services/api_service.dart
@@ -1,0 +1,19 @@
+import 'dart:convert';
+
+import 'package:http/http.dart' as http;
+
+/// Simple HTTP service that fetches JSON placeholder content.
+class ApiService {
+  const ApiService();
+
+  /// Fetches a post from jsonplaceholder.typicode.com and returns the decoded
+  /// JSON map.
+  Future<Map<String, dynamic>> fetchExamplePost() async {
+    final response =
+        await http.get(Uri.parse('https://jsonplaceholder.typicode.com/posts/1'));
+    if (response.statusCode == 200) {
+      return jsonDecode(response.body) as Map<String, dynamic>;
+    }
+    throw Exception('Failed to fetch data');
+  }
+}

--- a/lib/services/local_storage_service.dart
+++ b/lib/services/local_storage_service.dart
@@ -1,0 +1,44 @@
+import 'dart:convert';
+
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// Simple wrapper around [SharedPreferences] for saving and loading
+/// JSON encoded data. This can be extended to persist any model.
+class LocalStorageService {
+  LocalStorageService._();
+  static final LocalStorageService instance = LocalStorageService._();
+
+  static const _healthKey = 'health_entries';
+  static const _reminderKey = 'medication_reminders';
+
+  /// Saves a list of JSON encodable objects under the given key.
+  Future<void> _saveList(String key, List<dynamic> list) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(key, jsonEncode(list));
+  }
+
+  /// Loads a list of dynamic objects from storage. Returns an empty list if
+  /// nothing is stored.
+  Future<List<dynamic>> _loadList(String key) async {
+    final prefs = await SharedPreferences.getInstance();
+    final jsonStr = prefs.getString(key);
+    if (jsonStr == null) return [];
+    return jsonDecode(jsonStr) as List<dynamic>;
+  }
+
+  Future<void> saveHealthEntries(List<Map<String, dynamic>> entries) async {
+    await _saveList(_healthKey, entries);
+  }
+
+  Future<List<dynamic>> loadHealthEntries() async {
+    return _loadList(_healthKey);
+  }
+
+  Future<void> saveReminders(List<Map<String, dynamic>> reminders) async {
+    await _saveList(_reminderKey, reminders);
+  }
+
+  Future<List<dynamic>> loadReminders() async {
+    return _loadList(_reminderKey);
+  }
+}

--- a/lib/services/notification_service.dart
+++ b/lib/services/notification_service.dart
@@ -1,0 +1,37 @@
+import 'package:flutter_local_notifications/flutter_local_notifications.dart';
+
+/// Manages local notification scheduling. This contains only minimal logic and
+/// can be expanded later.
+class NotificationService {
+  NotificationService._();
+  static final NotificationService instance = NotificationService._();
+
+  final FlutterLocalNotificationsPlugin _plugin =
+      FlutterLocalNotificationsPlugin();
+
+  /// Initializes the underlying plugin. Call this before scheduling
+  /// notifications.
+  Future<void> init() async {
+    const android = AndroidInitializationSettings('@mipmap/ic_launcher');
+    const settings = InitializationSettings(android: android);
+    await _plugin.initialize(settings);
+  }
+
+  /// Schedules a simple notification at the given [dateTime].
+  Future<void> scheduleNotification(int id, String title, String body,
+      DateTime dateTime) async {
+    await _plugin.zonedSchedule(
+      id,
+      title,
+      body,
+      dateTime.toLocal(),
+      const NotificationDetails(
+        android: AndroidNotificationDetails('meds', 'Medication'),
+      ),
+      androidAllowWhileIdle: true,
+      uiLocalNotificationDateInterpretation:
+          UILocalNotificationDateInterpretation.absoluteTime,
+      matchDateTimeComponents: DateTimeComponents.time,
+    );
+  }
+}

--- a/lib/utils/app_theme.dart
+++ b/lib/utils/app_theme.dart
@@ -1,0 +1,25 @@
+import 'package:flutter/material.dart';
+
+/// Central place for defining the application theme.
+class AppTheme {
+  static const Color primaryColor = Color(0xFFF7931E);
+
+  /// Light theme with Material 3 enabled.
+  static ThemeData light() {
+    return ThemeData(
+      useMaterial3: true,
+      colorScheme: ColorScheme.fromSeed(seedColor: primaryColor),
+      fontFamily: 'Sarabun',
+    );
+  }
+
+  /// Dark theme variant.
+  static ThemeData dark() {
+    return ThemeData(
+      useMaterial3: true,
+      brightness: Brightness.dark,
+      colorScheme: ColorScheme.fromSeed(seedColor: primaryColor, brightness: Brightness.dark),
+      fontFamily: 'Sarabun',
+    );
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -39,6 +39,10 @@ dependencies:
   pdf: ^3.10.7
   printing: ^5.12.0
   youtube_player_flutter: ^8.1.2
+  go_router: ^13.2.0
+  http: ^1.2.1
+  shared_preferences: ^2.2.2
+  flutter_local_notifications: ^17.1.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- update README for Wellness App
- add dependencies for go_router, shared_preferences, http and local notifications
- implement local storage service and notification service
- enhance providers to persist data
- create onboarding, login, register, dashboard and other screens
- implement router-based navigation with Material 3 theme

## Testing
- `flutter pub get` *(fails: flutter not installed)*
- `dart analyze` *(fails: dart not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6859228123588329831298dcec7028d2